### PR TITLE
Add Documentation to nav bar

### DIFF
--- a/src/resources/js/layouts/main.vue
+++ b/src/resources/js/layouts/main.vue
@@ -217,6 +217,22 @@
                         </li>
                         <li class="nav-item">
                             <a
+                                href="https://docs.interop.gsmainclusivetechlab.io/"
+                                class="nav-link"
+                                target="_blank"
+                            >
+                                <span
+                                    class="nav-link-icon d-md-none d-lg-inline-block"
+                                >
+                                    <icon name="book" />
+                                </span>
+                                <span class="nav-link-title">
+                                    Documentation
+                                </span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a
                                 href="https://www.gsma.com/lab"
                                 class="nav-link"
                                 target="_blank"


### PR DESCRIPTION
Here's what it looks like:

<img width="451" alt="Screenshot 2020-06-29 at 13 27 44" src="https://user-images.githubusercontent.com/23292626/86005299-5f54fa80-ba0c-11ea-942a-bcbcacc7f965.png">
