### PR TITLE
Feature: Add message log pages

### DIFF
--- a/src/app/Exceptions/Handler.php
+++ b/src/app/Exceptions/Handler.php
@@ -2,9 +2,15 @@
 
 namespace App\Exceptions;
 
+use App\Http\Client\Request;
+use App\Models\MessageMismatch;
+use GuzzleHttp\Psr7\ServerRequest;
 use Inertia\Inertia;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 class Handler extends ExceptionHandler
 {
@@ -45,5 +51,95 @@ class Handler extends ExceptionHandler
         }
 
         return parent::renderHttpException($e);
+    }
+
+    private function coerceToMessageMismatch(Throwable $e)
+    {
+        if ($e instanceof ModelNotFoundException) {
+            $ids = $e->getIds();
+            $ids = json_encode(is_int($ids) ? [$ids] : $ids);
+            switch ($e->getModel()) {
+                case 'App\\Models\\Session':
+                    $e = new MessageMismatchException(
+                        null,
+                        404,
+                        "Unable to find a session in $ids. Please check the request URL."
+                    );
+                    break;
+                case 'App\\Models\\Component':
+                    $e = new MessageMismatchException(
+                        null,
+                        404,
+                        "Unable to find a component in $ids. Please check the request URL."
+                    );
+                    break;
+            }
+        }
+
+        return $e;
+    }
+
+    /**
+     * @param Throwable $e
+     * @throws \Exception
+     */
+    public function report(Throwable $e)
+    {
+        $e = $this->coerceToMessageMismatch($e);
+
+        if ($e instanceof MessageMismatchException) {
+            $this->reportMessageMismatch($e);
+        }
+        if ($e instanceof NotFoundHttpException) {
+            $this->reportMessageMismatch(
+                new MessageMismatchException(
+                    null,
+                    404,
+                    'Attempt to call non-existent path'
+                )
+            );
+        }
+
+        parent::report($e);
+    }
+
+    /**
+     * @param MessageMismatchException $e
+     */
+    protected function reportMessageMismatch(MessageMismatchException $e)
+    {
+        $request = request();
+        $mismatch = new MessageMismatch([
+            'exception' => $e->getMessage(),
+            'request' => new Request(
+                new ServerRequest(
+                    $request->method(),
+                    $request->url(),
+                    $request->headers->all(),
+                    $request->getContent()
+                )
+            ),
+        ]);
+        $session = $e->getSession();
+        if ($session != null) {
+            $mismatch->session()->associate($session);
+        }
+
+        $mismatch->save();
+    }
+
+    /**
+     * Render an exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Exception  $exception
+     * @return \Illuminate\Http\Response
+     */
+
+    public function render($request, Throwable $e)
+    {
+        $e = $this->coerceToMessageMismatch($e);
+
+        return parent::render($request, $e);
     }
 }

--- a/src/app/Exceptions/MessageMismatchException.php
+++ b/src/app/Exceptions/MessageMismatchException.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use App\Models\Session;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class MessageMismatchException extends HttpException
+{
+    /**
+     * @var Session|null
+     */
+    protected $session;
+
+    /**
+     * MessageMismatchException constructor.
+     * @param Session|null $session
+     * @param int $statusCode
+     * @param string|null $message
+     */
+    public function __construct(
+        ?Session $session,
+        int $statusCode,
+        string $message = null
+    ) {
+        parent::__construct($statusCode, $message);
+        $this->session = $session;
+    }
+
+    /**
+     * @return Session|null
+     */
+    public function getSession()
+    {
+        return $this->session;
+    }
+}

--- a/src/app/Http/Controllers/MessageLogController.php
+++ b/src/app/Http/Controllers/MessageLogController.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\SessionResource;
+use App\Http\Resources\MessageLogResource;
+use App\Http\Resources\UseCaseResource;
+use App\Models\Session;
+use App\Models\MessageLog;
+use App\Models\UseCase;
+use Inertia\Inertia;
+
+class MessageLogController extends Controller
+{
+    /**
+     * TestCaseController constructor.
+     */
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified']);
+    }
+
+    /**
+     * @param Session $session
+     * @return \Inertia\Response
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function admin()
+    {
+        $this->authorize('viewAny', MessageLog::class);
+        return Inertia::render('admin/message-log/index', [
+            'logItems' => MessageLogResource::collection(
+                MessageLog::with(['testRun', 'testCase', 'testStep', 'session'])
+                    ->latest()
+                    ->paginate()
+            ),
+        ]);
+    }
+
+    /**
+     * @param Session $session
+     * @return \Inertia\Response
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function index(Session $session)
+    {
+        $this->authorize('view', $session);
+
+        return Inertia::render('sessions/message-log/index', [
+            'session' => (new SessionResource(
+                $session->load([
+                    'testCases' => function ($query) {
+                        return $query->with(['useCase', 'lastTestRun']);
+                    },
+                    'components' => function ($query) {
+                        return $query->with(['connections']);
+                    },
+                ])
+            ))->resolve(),
+            'useCases' => UseCaseResource::collection(
+                UseCase::with([
+                    'testCases' => function ($query) use ($session) {
+                        $query
+                            ->with([
+                                'lastTestRun' => function ($query) use (
+                                    $session
+                                ) {
+                                    $query->where('session_id', $session->id);
+                                },
+                            ])
+                            ->whereHas('sessions', function ($query) use (
+                                $session
+                            ) {
+                                $query->whereKey($session->getKey());
+                            });
+                    },
+                ])
+                    ->whereHas('testCases', function ($query) use ($session) {
+                        $query->whereHas('sessions', function ($query) use (
+                            $session
+                        ) {
+                            $query->whereKey($session->getKey());
+                        });
+                    })
+                    ->get()
+            ),
+            'logItems' => MessageLogResource::collection(
+                $session
+                    ->messageLog()
+                    ->with(['testRun', 'testCase', 'testStep'])
+                    ->latest()
+                    ->paginate()
+            ),
+        ]);
+    }
+}

--- a/src/app/Http/Controllers/Testing/Handlers/SendingRejectedHandler.php
+++ b/src/app/Http/Controllers/Testing/Handlers/SendingRejectedHandler.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Testing\Handlers;
 
+use App\Exceptions\MessageMismatchException;
 use App\Models\TestResult;
 use Throwable;
 
@@ -29,6 +30,10 @@ class SendingRejectedHandler
         $this->testResult->fail($exception->getMessage());
         $this->testResult->testRun->complete();
 
-        return $exception;
+        throw new MessageMismatchException(
+            $this->testResult->session,
+            500,
+            $exception->getMessage()
+        );
     }
 }

--- a/src/app/Http/Controllers/Testing/SimulatorController.php
+++ b/src/app/Http/Controllers/Testing/SimulatorController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Testing;
 
+use App\Exceptions\MessageMismatchException;
 use App\Http\Controllers\Controller;
 use App\Http\Controllers\Testing\Handlers\MapRequestHandler;
 use App\Http\Controllers\Testing\Handlers\MapResponseHandler;
@@ -88,7 +89,15 @@ class SimulatorController extends Controller
                     })
                     ->count()
             )
-            ->firstOrFail();
+            ->first();
+
+        if ($testStep === null) {
+            throw new MessageMismatchException(
+                $testRun->session,
+                404,
+                'Unable to match simulator request with an awaited test step. Please check the test preconditions.'
+            );
+        }
 
         $testResult = $testRun
             ->testResults()

--- a/src/app/Http/Resources/MessageLogResource.php
+++ b/src/app/Http/Resources/MessageLogResource.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MessageLogResource extends JsonResource
+{
+    /**
+     * @param  \App\Models\MessageLog  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'type' => $this->type,
+            'request' => $this->request->toArray(),
+            'exception' => $this->exception,
+            'created_at' => $this->created_at->diffForHumans(),
+            'session' => new SessionResource($this->whenLoaded('session')),
+            'test_case' => new TestCaseResource($this->whenLoaded('testCase')),
+            'test_step' => new TestStepResource($this->whenLoaded('testStep')),
+            'test_run' => new TestRunResource($this->whenLoaded('testRun')),
+        ];
+    }
+}

--- a/src/app/Models/MessageLog.php
+++ b/src/app/Models/MessageLog.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Casts\RequestCast;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @mixin \Eloquent
+ */
+class MessageLog extends Model
+{
+    const UPDATED_AT = null;
+
+    /**
+     * @var string
+     */
+    protected $table = 'message_log';
+
+    /**
+     * @var array
+     */
+    protected $fillable = ['request', 'exception'];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'request' => RequestCast::class,
+    ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function session()
+    {
+        return $this->belongsTo(Session::class, 'session_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function testStep()
+    {
+        return $this->belongsTo(TestStep::class, 'test_step_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function testRun()
+    {
+        return $this->belongsTo(TestRun::class, 'test_run_id');
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function testCase()
+    {
+        return $this->hasOneThrough(
+            TestCase::class,
+            TestRun::class,
+            'id',
+            'id',
+            'test_run_id',
+            'test_case_id'
+        );
+    }
+}

--- a/src/app/Models/MessageMismatch.php
+++ b/src/app/Models/MessageMismatch.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Casts\RequestCast;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @mixin \Eloquent
+ */
+class MessageMismatch extends Model
+{
+    const UPDATED_AT = null;
+
+    /**
+     * @var string
+     */
+    protected $table = 'message_mismatches';
+
+    /**
+     * @var array
+     */
+    protected $fillable = ['request', 'exception'];
+
+    /**
+     * @var array
+     */
+    protected $casts = [
+        'request' => RequestCast::class,
+    ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function session()
+    {
+        return $this->belongsTo(Session::class, 'session_id');
+    }
+}

--- a/src/app/Models/Session.php
+++ b/src/app/Models/Session.php
@@ -53,6 +53,27 @@ class Session extends Model
     }
 
     /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function testResults()
+    {
+        return $this->hasManyThrough(
+            TestResult::class,
+            TestRun::class,
+            'session_id',
+            'test_run_id'
+        );
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function messageLog()
+    {
+        return $this->hasMany(MessageLog::class, 'session_id');
+    }
+
+    /**
      * @return mixed
      */
     public function lastTestRun()

--- a/src/app/Policies/MessageLogPolicy.php
+++ b/src/app/Policies/MessageLogPolicy.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\MessageLog;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class MessageLogPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * @param  User  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        debug('Checking messsage log canAdmin');
+        return $user->canAdmin();
+    }
+
+    /**
+     * @param  User  $user
+     * @param  MessageLog  $model
+     * @return mixed
+     */
+    public function view(User $user, MessageLog $model)
+    {
+        if ($user->canAdmin()) {
+            return true;
+        }
+        $session = $model->session();
+        if ($session) {
+            return $session->owner->is($user);
+        }
+        return false;
+    }
+}

--- a/src/app/Providers/AuthServiceProvider.php
+++ b/src/app/Providers/AuthServiceProvider.php
@@ -2,20 +2,22 @@
 
 namespace App\Providers;
 
+use App\Models\ApiSpec;
 use App\Models\Component;
 use App\Models\Group;
 use App\Models\GroupUser;
+use App\Models\MessageLog;
 use App\Models\Session;
-use App\Models\ApiSpec;
 use App\Models\TestCase;
 use App\Models\TestStep;
 use App\Models\UseCase;
 use App\Models\User;
+use App\Policies\ApiSpecPolicy;
 use App\Policies\ComponentPolicy;
 use App\Policies\GroupUserPolicy;
 use App\Policies\GroupPolicy;
+use App\Policies\MessageLogPolicy;
 use App\Policies\SessionPolicy;
-use App\Policies\ApiSpecPolicy;
 use App\Policies\TestCasePolicy;
 use App\Policies\TestStepPolicy;
 use App\Policies\UseCasePolicy;
@@ -37,6 +39,7 @@ class AuthServiceProvider extends ServiceProvider
         TestCase::class => TestCasePolicy::class,
         TestStep::class => TestStepPolicy::class,
         UseCase::class => UseCasePolicy::class,
+        MessageLog::class => MessageLogPolicy::class,
     ];
 
     /**

--- a/src/app/Providers/InertiaServiceProvider.php
+++ b/src/app/Providers/InertiaServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\Session;
 use App\Models\ApiSpec;
 use App\Models\TestCase;
 use App\Models\UseCase;
+use App\Models\MessageLog;
 use App\Models\User;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\ViewErrorBag;
@@ -98,6 +99,11 @@ class InertiaServiceProvider extends ServiceProvider
                                     'create' => auth()
                                         ->user()
                                         ->can('create', TestCase::class),
+                                ],
+                                'message_log' => [
+                                    'viewAny' => auth()
+                                        ->user()
+                                        ->can('viewAny', MessageLog::class),
                                 ],
                             ],
                         ]

--- a/src/database/migrations/2020_07_09_182001_create_message_mismatches_table.php
+++ b/src/database/migrations/2020_07_09_182001_create_message_mismatches_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMessageMismatchesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('message_mismatches', function (Blueprint $table) {
+            $table->id();
+            $table
+                ->foreignId('session_id')
+                ->nullable()
+                ->constrained()
+                ->onDelete('cascade');
+            $table->json('request');
+            $table->text('exception');
+            $table->timestamp('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('message_mismatches');
+    }
+}

--- a/src/database/migrations/2020_07_13_182001_create_message_log_view.php
+++ b/src/database/migrations/2020_07_13_182001_create_message_log_view.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class CreateMessageLogView extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement($this->dropView());
+
+        DB::statement($this->createView());
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement($this->dropView());
+    }
+
+    private function createView(): string
+    {
+        return <<<SQL
+CREATE VIEW `message_log` AS
+(
+    SELECT
+        'MISMATCH' AS 'type',
+        `id`,
+        `session_id`,
+        `request`,
+        `exception`,
+        `created_at`,
+        NULL AS test_run_id,
+        NULL AS test_step_id
+    FROM
+        `message_mismatches`
+)
+UNION
+    (
+    SELECT
+        'RESULT' AS 'type',
+        `test_results`.`id`,
+        `test_runs`.`session_id`,
+        `request`,
+        `exception`,
+        `test_results`.`created_at`,
+        `test_run_id`,
+        `test_step_id`
+    FROM
+        `test_results`
+    INNER JOIN `test_runs` ON `test_runs`.`id` = `test_results`.`test_run_id`
+)
+SQL;
+    }
+    private function dropView(): string
+    {
+        return <<<SQL
+DROP VIEW IF EXISTS `message_log`;
+SQL;
+    }
+}

--- a/src/resources/js/components/mismatch-modal.vue
+++ b/src/resources/js/components/mismatch-modal.vue
@@ -1,0 +1,139 @@
+<template>
+    <div>
+        <button
+            class="btn btn-secondary"
+            v-b-modal="`modal-request-${message.type}-${message.id}`"
+        >
+            Request
+        </button>
+        <b-modal
+            :id="`modal-request-${message.type}-${message.id}`"
+            size="lg"
+            centered
+            hide-footer
+            hide-header-close
+            title="Request"
+        >
+            <div class="border">
+                <div class="d-flex" v-if="message.exception">
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Exception</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <div class="mb-0 p-0">
+                            {{ message.exception }}
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex" v-if="message.request.uri">
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>{{
+                            message.type === 'RESULT'
+                                ? 'Outbound URL'
+                                : 'Inbound URL'
+                        }}</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <pre class="mb-0 p-0">{{
+                            message.request.uri.trim()
+                        }}</pre>
+                    </div>
+                </div>
+                <div class="d-flex" v-if="message.type === 'MISMATCH'">
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Session ID</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <pre class="mb-0 p-0">{{ path.session || '-' }}</pre>
+                    </div>
+                </div>
+                <div class="d-flex" v-if="message.type === 'MISMATCH'">
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Source Component ID</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <pre class="mb-0 p-0">{{ path.source || '-' }}</pre>
+                    </div>
+                </div>
+                <div class="d-flex" v-if="message.type === 'MISMATCH'">
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Target Component ID</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <pre class="mb-0 p-0">{{ path.target || '-' }}</pre>
+                    </div>
+                </div>
+                <div class="d-flex" v-if="message.type === 'MISMATCH'">
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Target Path</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <pre class="mb-0 p-0">{{ path.path || '-' }}</pre>
+                    </div>
+                </div>
+                <div class="d-flex" v-if="message.request.method">
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Method</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <div class="mb-0 p-0">
+                            {{ message.request.method }}
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="d-flex"
+                    v-if="collect(message.request.headers).count()"
+                >
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Headers</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <div class="mb-0 p-0">
+                            <json-tree
+                                :data="message.request.headers"
+                                :deep="1"
+                                :show-line="false"
+                                class="p-2"
+                            ></json-tree>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="d-flex"
+                    v-if="collect(message.request.body).count()"
+                >
+                    <div class="w-25 px-4 py-2 border">
+                        <strong>Body</strong>
+                    </div>
+                    <div class="w-75 px-4 py-2 border">
+                        <div class="mb-0 p-0">
+                            <json-tree
+                                :data="message.request.body"
+                                :deep="1"
+                                :show-line="false"
+                                class="p-2"
+                            ></json-tree>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </b-modal>
+    </div>
+</template>
+
+<script>
+export default {
+    components: {},
+    props: {
+        path: {
+            type: Object,
+            required: true,
+        },
+        message: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>

--- a/src/resources/js/layouts/main.vue
+++ b/src/resources/js/layouts/main.vue
@@ -58,6 +58,7 @@
                                 $page.auth.user.can.sessions.viewAny ||
                                 $page.auth.user.can.api_specs.viewAny ||
                                 $page.auth.user.can.use_cases.viewAny ||
+                                $page.auth.user.can.message_log.viewAny ||
                                 $page.auth.user.can.test_cases.viewAny
                             )"
                         >
@@ -111,6 +112,14 @@
                                     class="text-reset dropdown-item"
                                 >
                                     Test Cases
+                                </inertia-link>
+                            </li>
+                            <li v-if="$page.auth.user.can.message_log.viewAny">
+                                <inertia-link
+                                    :href="route('admin.message-log')"
+                                    class="text-reset dropdown-item"
+                                >
+                                    Message Log
                                 </inertia-link>
                             </li>
                         </b-nav-item-dropdown>

--- a/src/resources/js/layouts/sessions/main.vue
+++ b/src/resources/js/layouts/sessions/main.vue
@@ -2,7 +2,7 @@
     <layout>
         <div class="row">
             <div class="col-md-12">
-                <div class="row border-bottom pb-4 align-items-center">
+                <div class="row border-bottom pb-4 align-items-stretch">
                     <div class="col-6 d-flex flex-column">
                         <div class="page-pretitle font-weight-normal">
                             <breadcrumb
@@ -14,7 +14,18 @@
                             <b>{{ session.name }}</b>
                         </h1>
                     </div>
-                    <div class="ml-auto col-2 d-flex justify-content-end">
+                    <div class="ml-auto col-1 d-flex justify-content-end">
+                        <inertia-link
+                            :href="
+                                route('sessions.message-log.index', session.id)
+                            "
+                            class="btn btn-secondary mr-2"
+                        >
+                            <icon name="list"></icon>
+                            Log
+                        </inertia-link>
+                    </div>
+                    <div class="col-2 d-flex justify-content-end">
                         <div class="w-100">
                             <div>
                                 Execution:
@@ -64,7 +75,10 @@
                             </div>
                             <div class="card-body p-0">
                                 <ul class="list-unstyled">
-                                    <li v-for="useCase in useCases.data">
+                                    <li
+                                        v-for="useCase in useCases.data"
+                                        v-bind:key="useCase.id"
+                                    >
                                         <b
                                             class="d-block dropdown-toggle py-2 px-3 border-bottom"
                                             v-b-toggle="
@@ -111,6 +125,9 @@
                                                                         'positive'
                                                                     )
                                                                     .all()"
+                                                                v-bind:key="
+                                                                    positiveTestCase.id
+                                                                "
                                                                 class="list-group-item-action border-bottom"
                                                                 v-bind:class="{
                                                                     'bg-body':
@@ -211,6 +228,9 @@
                                                                         'negative'
                                                                     )
                                                                     .all()"
+                                                                v-bind:key="
+                                                                    negativeTestCase.id
+                                                                "
                                                                 class="list-group-item-action border-bottom"
                                                                 v-bind:class="{
                                                                     'bg-body':

--- a/src/resources/js/layouts/sessions/test-case.vue
+++ b/src/resources/js/layouts/sessions/test-case.vue
@@ -7,7 +7,7 @@
     >
         <div class="row">
             <div class="col-md-12">
-                <div class="row border-bottom pb-4 align-items-center">
+                <div class="row border-bottom pb-4 align-items-stretch">
                     <div class="col-6 d-flex flex-column">
                         <div class="page-pretitle font-weight-normal">
                             <breadcrumb
@@ -19,7 +19,18 @@
                             <b>{{ session.name }}</b>
                         </h1>
                     </div>
-                    <div class="ml-auto col-2 d-flex justify-content-end">
+                    <div class="ml-auto col-1 d-flex justify-content-end">
+                        <inertia-link
+                            :href="
+                                route('sessions.message-log.index', session.id)
+                            "
+                            class="btn btn-secondary mr-2"
+                        >
+                            <icon name="list"></icon>
+                            Log
+                        </inertia-link>
+                    </div>
+                    <div class="col-2 d-flex justify-content-end">
                         <div class="w-100">
                             <div>
                                 Execution:

--- a/src/resources/js/pages/admin/message-log/index.vue
+++ b/src/resources/js/pages/admin/message-log/index.vue
@@ -1,0 +1,146 @@
+<template>
+    <layout>
+        <div class="page-header">
+            <div class="row align-items-center">
+                <div class="col-auto">
+                    <div class="page-pretitle">
+                        Administration
+                    </div>
+                    <h2 class="page-title">
+                        <b>Message Log</b>
+                    </h2>
+                </div>
+            </div>
+        </div>
+        On the backend, a new table has been added, tracking mismatched
+        requests. Additionally, a MySQL View has been added, which combines
+        these mismatched requests with the well-matched test results table.
+        Corresponding Models, Controllers, Resources and Policies have also been
+        added. Additionally, the error messages returned to users when a message
+        is mismatched has been improved where possible.
+        <div class="card">
+            <div class="card-header">
+                <h2 class="card-title">
+                    <b>Message Log</b>
+                </h2>
+            </div>
+            <div class="table-responsive mb-0">
+                <table class="table table-striped table-hover card-table">
+                    <thead>
+                        <tr>
+                            <th class="text-nowrap w-20">URL</th>
+                            <th class="text-nowrap w-auto">Matched Step</th>
+                            <th class="text-nowrap w-15">Date</th>
+                            <th class="text-nowrap w-15">Data</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr
+                            v-for="message in logItems.data"
+                            v-bind:key="message.type + message.id"
+                        >
+                            <td>
+                                <div class="d-flex align-items-center">
+                                    {{ message.request.method }}
+                                    {{
+                                        message.type === 'MISMATCH'
+                                            ? processMismatchPath(
+                                                  message.request.path
+                                              ).truncated
+                                            : message.request.path
+                                    }}
+                                </div>
+                            </td>
+
+                            <td v-if="message.type === 'RESULT'">
+                                <inertia-link
+                                    :href="
+                                        route(
+                                            'sessions.test-cases.test-runs.show',
+                                            [
+                                                message.session.id,
+                                                message.test_case.id,
+                                                message.test_run.id,
+                                                message.test_step.position,
+                                            ]
+                                        )
+                                    "
+                                >
+                                    {{ message.test_case.name }}, Step
+                                    {{ message.test_step.position }}
+                                </inertia-link>
+                            </td>
+                            <td v-else>
+                                -
+                            </td>
+
+                            <td>
+                                {{ message.created_at }}
+                            </td>
+                            <td>
+                                <mismatch-modal
+                                    :message="message"
+                                    :path="
+                                        processMismatchPath(
+                                            message.request.path
+                                        )
+                                    "
+                                ></mismatch-modal>
+                            </td>
+                        </tr>
+                        <tr v-if="!logItems.data.length">
+                            <td class="text-center" colspan="5">
+                                No Results
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <pagination
+                :meta="logItems.meta"
+                :links="logItems.links"
+                class="card-footer"
+            />
+        </div>
+    </layout>
+</template>
+
+<script>
+import Layout from '@/layouts/main';
+import MismatchModal from '@/components/mismatch-modal';
+
+export default {
+    components: {
+        Layout,
+        'mismatch-modal': MismatchModal,
+    },
+    props: {
+        logItems: {
+            type: Object,
+            required: true,
+        },
+    },
+    methods: {
+        processMismatchPath: function (path) {
+            const match = path.match(
+                /\/testing\/([^\/]+)\/([^\/]+)\/([^\/]+)\/sut(.+)/
+            );
+            const session = match && match[1];
+            const source = match && match[2];
+            const target = match && match[3];
+            const destPath = match && match[4];
+            return {
+                original: path,
+                session,
+                source,
+                target,
+                path: destPath,
+                truncated:
+                    destPath ||
+                    (path.length > 30 ? `...${path.substr(-30)}` : path),
+            };
+        },
+    },
+};
+</script>

--- a/src/resources/js/pages/admin/users/index.vue
+++ b/src/resources/js/pages/admin/users/index.vue
@@ -4,10 +4,10 @@
             <div class="row align-items-center">
                 <div class="col-auto">
                     <div class="page-pretitle">
-                        Administration
+                        administration
                     </div>
                     <h2 class="page-title">
-                        <b>Users</b>
+                        <b>users</b>
                     </h2>
                 </div>
             </div>

--- a/src/resources/js/pages/sessions/message-log/index.vue
+++ b/src/resources/js/pages/sessions/message-log/index.vue
@@ -1,0 +1,136 @@
+<template>
+    <session :session="session" :useCases="useCases">
+        <div class="card">
+            <div class="card-header">
+                <h2 class="card-title">
+                    <b>Message Log</b>
+                </h2>
+            </div>
+            <div class="table-responsive mb-0">
+                <table class="table table-striped table-hover card-table">
+                    <thead>
+                        <tr>
+                            <th class="text-nowrap w-20">URL</th>
+                            <th class="text-nowrap w-auto">Matched Step</th>
+                            <th class="text-nowrap w-15">Date</th>
+                            <th class="text-nowrap w-15">Data</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr
+                            v-for="message in logItems.data"
+                            v-bind:key="message.type + message.id"
+                        >
+                            <td>
+                                <div class="d-flex align-items-center">
+                                    {{ message.request.method }}
+                                    {{
+                                        message.type === 'MISMATCH'
+                                            ? processMismatchPath(
+                                                  message.request.path
+                                              ).truncated
+                                            : message.request.path
+                                    }}
+                                </div>
+                            </td>
+
+                            <td v-if="message.type === 'RESULT'">
+                                <inertia-link
+                                    :href="
+                                        route(
+                                            'sessions.test-cases.test-runs.show',
+                                            [
+                                                session.id,
+                                                message.test_case.id,
+                                                message.test_run.id,
+                                                message.test_step.position,
+                                            ]
+                                        )
+                                    "
+                                >
+                                    {{ message.test_case.name }}, Step
+                                    {{ message.test_step.position }}
+                                </inertia-link>
+                            </td>
+                            <td v-else>
+                                -
+                            </td>
+
+                            <td>
+                                {{ message.created_at }}
+                            </td>
+                            <td>
+                                <mismatch-modal
+                                    :message="message"
+                                    :path="
+                                        processMismatchPath(
+                                            message.request.path
+                                        )
+                                    "
+                                ></mismatch-modal>
+                            </td>
+                        </tr>
+                        <tr v-if="!logItems.data.length">
+                            <td class="text-center" colspan="5">
+                                No Results
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <pagination
+                :meta="logItems.meta"
+                :links="logItems.links"
+                class="card-footer"
+            />
+        </div>
+    </session>
+</template>
+
+<script>
+import Session from '@/layouts/sessions/main';
+import MismatchModal from '@/components/mismatch-modal';
+
+export default {
+    components: {
+        Session,
+        'mismatch-modal': MismatchModal,
+    },
+    props: {
+        session: {
+            type: Object,
+            required: true,
+        },
+        useCases: {
+            type: Object,
+            required: true,
+        },
+        logItems: {
+            type: Object,
+            required: true,
+        },
+    },
+    methods: {
+        processMismatchPath: function (path) {
+            const match = path.match(
+                /\/testing\/([^\/]+)\/([^\/]+)\/([^\/]+)\/sut(.+)/
+            );
+            const session = match && match[1];
+            const source = match && match[2];
+            const target = match && match[3];
+            const destPath = match && match[4];
+            return {
+                original: path,
+                session,
+                source,
+                target,
+                path: destPath,
+                truncated:
+                    destPath ||
+                    (path.length > 30 ? `...${path.substr(-30)}` : path),
+            };
+        },
+    },
+};
+</script>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -59,6 +59,10 @@ Route::name('sessions.')
             'chart'
         );
         Route::get(
+            '{session}/message-log',
+            '\App\Http\Controllers\MessageLogController@index'
+        )->name('message-log.index');
+        Route::get(
             '{session}/test-cases/{testCase}',
             'TestCaseController@show'
         )->name('test-cases.show');
@@ -131,7 +135,7 @@ Route::name('testing.')
     ->namespace('Testing')
     ->group(function () {
         Route::any(
-            '{session:uuid}/{component:uuid}/{connection:uuid}/sut/{path?}',
+            '{session:uuid}/{componentId}/{connectionId}/sut/{path?}',
             'SutController'
         )
             ->name('sut')
@@ -175,6 +179,10 @@ Route::name('admin.')
                 )->name('promote-role');
             });
         Route::resource('groups', 'GroupController')->except(['show']);
+        Route::get(
+            'message-log',
+            '\App\Http\Controllers\MessageLogController@admin'
+        )->name('message-log');
         Route::resource('sessions', 'SessionController')->only(['index']);
         Route::resource('api-specs', 'ApiSpecController')->only([
             'index',
@@ -210,3 +218,7 @@ Route::name('admin.')
                 )->name('toggle-public');
             });
     });
+
+Route::get('/health', function () {
+    return 'ok';
+});


### PR DESCRIPTION
## Summary of Changes
On the backend, a new table has been added, tracking mismatched requests. Additionally, a MySQL View has been added, which combines these mismatched requests with the well-matched test results table. Corresponding Models, Controllers, Resources and Policies have also been added. Additionally, the error messages returned to users when a message is mismatched has been improved where possible.

On the frontend, two new views are added - one for users to view the full logs for a session to which they have access, and another for admins to view the full logs across all sessions. This admin view also includes logs of requests which did not match any test route at all, in a further attempt to assist with debugging missing messages. In both cases, the user can click the "Request" button to view details of the unmatched requests, including the exception thrown, and a guess at the identified session and component IDs (where these are unparseable, the fields are left blank). 

Additionally, I added a `/health` endpoint after noticing the 404s in the screenshot below. 

## Session Log
![image](https://user-images.githubusercontent.com/1517675/87454217-9413a500-c5fb-11ea-9149-0a24981bcd4e.png)
![image](https://user-images.githubusercontent.com/1517675/87454261-a392ee00-c5fb-11ea-911b-dce78fb866bb.png)

## Admin Log
![image](https://user-images.githubusercontent.com/1517675/87454161-8100d500-c5fb-11ea-9dad-aaa8c39e74bc.png)


