### PR TITLE
Feature/add-testcases-id

### DIFF
--- a/src/resources/js/pages/sessions/show.vue
+++ b/src/resources/js/pages/sessions/show.vue
@@ -41,6 +41,7 @@
                     <table class="table table-striped table-hover card-table">
                         <thead>
                             <tr>
+                                <th class="text-nowrap w-auto">ID</th>
                                 <th class="text-nowrap w-auto">Test Case</th>
                                 <th class="text-nowrap w-auto">Run ID</th>
                                 <th class="text-nowrap w-auto">Status</th>
@@ -50,6 +51,7 @@
                         </thead>
                         <tbody>
                             <tr v-for="testRun in testRuns.data">
+                                <td>{{ testRun.id }}</td>
                                 <td>
                                     <inertia-link
                                         :href="

--- a/src/resources/js/pages/sessions/show.vue
+++ b/src/resources/js/pages/sessions/show.vue
@@ -43,7 +43,6 @@
                             <tr>
                                 <th class="text-nowrap w-auto">ID</th>
                                 <th class="text-nowrap w-auto">Test Case</th>
-                                <th class="text-nowrap w-auto">Run ID</th>
                                 <th class="text-nowrap w-auto">Status</th>
                                 <th class="text-nowrap w-auto">Duration</th>
                                 <th class="text-nowrap w-auto">Date</th>
@@ -51,7 +50,22 @@
                         </thead>
                         <tbody>
                             <tr v-for="testRun in testRuns.data">
-                                <td>{{ testRun.id }}</td>
+                                <td>
+                                    <inertia-link
+                                        :href="
+                                                route(
+                                                    'sessions.test-cases.test-runs.show',
+                                                    [
+                                                        testRun.session.id,
+                                                        testRun.testCase.id,
+                                                        testRun.id,
+                                                    ]
+                                                )
+                                            "
+                                    >
+                                        #{{ testRun.id }}
+                                    </inertia-link>
+                                </td>
                                 <td>
                                     <inertia-link
                                         :href="
@@ -62,22 +76,6 @@
                                         "
                                     >
                                         {{ testRun.testCase.name }}
-                                    </inertia-link>
-                                </td>
-                                <td>
-                                    <inertia-link
-                                        :href="
-                                            route(
-                                                'sessions.test-cases.test-runs.show',
-                                                [
-                                                    testRun.session.id,
-                                                    testRun.testCase.id,
-                                                    testRun.id,
-                                                ]
-                                            )
-                                        "
-                                    >
-                                        {{ testRun.uuid }}
                                     </inertia-link>
                                 </td>
                                 <td>

--- a/src/resources/js/pages/sessions/test-cases/show.vue
+++ b/src/resources/js/pages/sessions/test-cases/show.vue
@@ -40,6 +40,7 @@
                     <table class="table table-striped table-hover card-table">
                         <thead>
                             <tr>
+                                <th class="text-nowrap w-auto">ID</th>
                                 <th class="text-nowrap w-auto">Run ID</th>
                                 <th class="text-nowrap w-auto">Status</th>
                                 <th class="text-nowrap w-auto">Duration</th>
@@ -48,6 +49,7 @@
                         </thead>
                         <tbody>
                             <tr v-for="testRun in testRuns.data">
+                                <td>{{ testRun.id }}</td>
                                 <td>
                                     <inertia-link
                                         :href="

--- a/src/resources/js/pages/sessions/test-cases/show.vue
+++ b/src/resources/js/pages/sessions/test-cases/show.vue
@@ -41,7 +41,6 @@
                         <thead>
                             <tr>
                                 <th class="text-nowrap w-auto">ID</th>
-                                <th class="text-nowrap w-auto">Run ID</th>
                                 <th class="text-nowrap w-auto">Status</th>
                                 <th class="text-nowrap w-auto">Duration</th>
                                 <th class="text-nowrap w-auto">Date</th>
@@ -49,21 +48,20 @@
                         </thead>
                         <tbody>
                             <tr v-for="testRun in testRuns.data">
-                                <td>{{ testRun.id }}</td>
                                 <td>
                                     <inertia-link
                                         :href="
-                                            route(
-                                                'sessions.test-cases.test-runs.show',
-                                                [
-                                                    testRun.session.id,
-                                                    testRun.testCase.id,
-                                                    testRun.id,
-                                                ]
-                                            )
-                                        "
+                                                route(
+                                                    'sessions.test-cases.test-runs.show',
+                                                    [
+                                                        testRun.session.id,
+                                                        testRun.testCase.id,
+                                                        testRun.id,
+                                                    ]
+                                                )
+                                            "
                                     >
-                                        {{ testRun.uuid }}
+                                        #{{ testRun.id }}
                                     </inertia-link>
                                 </td>
                                 <td>


### PR DESCRIPTION
Closes #217

The session and test case pages now show the test run ID, as shown below:
![Screenshot_2020-07-24 Example Session - Interoperability Test Platform - GSMA](https://user-images.githubusercontent.com/23292626/88406743-05f0a900-cdc9-11ea-968b-1552578b2bfd.png)
![Screenshot_2020-07-24 Example Session - Interoperability Test Platform - GSMA(1)](https://user-images.githubusercontent.com/23292626/88406753-08530300-cdc9-11ea-9d4e-229f30b8d69c.png)

