### PR TITLE
Increase circle label in tutorial demos from 8 to 10%

### DIFF
--- a/src/resources/sass/ui/_tutorials.scss
+++ b/src/resources/sass/ui/_tutorials.scss
@@ -40,7 +40,7 @@ $tutorials-red-color: $primary;
       position: absolute;
       left: 0;
       bottom: 0;
-      height: 8%;
+      height: 10%;
       width: 100%;
       text-align: center;
       font-weight: 600;


### PR DESCRIPTION
Closes #219 

The black bar in the demo tutorials are now slightly bigger, as shown below:

Before:
![84296340-40a4c780-ab22-11ea-81f5-d685aa9d2b32](https://user-images.githubusercontent.com/23292626/88407434-03db1a00-cdca-11ea-89d5-db2e7e18e016.png)

After:
![Screenshot_2020-07-24 Tutorials - Interoperability Test Platform - GSMA](https://user-images.githubusercontent.com/23292626/88407453-0b9abe80-cdca-11ea-8c65-1f876b9f0348.png)