### PR TITLE
[CI] Store SQL backup on host server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,13 +211,14 @@ jobs:
               && (echo "Backing up DB" && npm run --silent backup > ./backup.sql)) \
               || (echo "No DB to back up" && touch ./backup.sql)
       - run:
+          name: Store backup
+          command: scp ./backup.sql "<< parameters.host >>:/var/backups/circleci/`date +"%b%d-%Y-%H%M%S"`.backup.sql"
+      - run:
           name: Run migrations
           command: |
             (npm run --silent has-db \
               && (echo "Migrating DB" && npm run --silent migrate)) \
               || (echo "Seeding DB" && npm run --silent seed)
-      - store_artifacts:
-          path: ./backup.sql
       - run:
           name: Run docker-compose up
           command: npm run prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,9 @@ jobs:
               || (echo "No DB to back up" && touch ./backup.sql)
       - run:
           name: Store backup
-          command: scp ./backup.sql "<< parameters.host >>:/var/backups/circleci/`date +"%b%d-%Y-%H%M%S"`.backup.sql"
+          command:
+            scp ./backup.sql "<< parameters.host >>:/var/backups/circleci/`date
+            +"%b%d-%Y-%H%M%S"`.backup.sql"
       - run:
           name: Run migrations
           command: |
@@ -226,8 +228,8 @@ jobs:
           condition: << parameters.mailhog >>
           steps:
             - run:
-                npm run docker-base -- -f compose/mailhog.yml up -d mailhog
-                --force-recreate
+                npm run docker-base -- -f compose/mailhog.yml up
+                --force-recreate -d mailhog
 
 workflows:
   version: 2


### PR DESCRIPTION
Previously the SQL data backup was stored within circleCI. This created some data privacy issues, so they are now stored in a predefined directory on the host machine. In future, we could consider storing them in an S3 bucket instead.

There's also a fix in here for the mailhog deployment, which didn't previously work. 