### PR TITLE
cURL Syntax Fix

### DIFF
--- a/src/resources/js/components/clipboard-json-to-curl.vue
+++ b/src/resources/js/components/clipboard-json-to-curl.vue
@@ -22,7 +22,7 @@ export default {
             }
 
             const info = `${request['method']} '${request['uri']}'`;
-            const body = `--data-raw ${JSON.stringify(request['body'])}`;
+            const body = `--data-raw '${JSON.stringify(request['body'])}'`;
             const result = `curl --location --request ${info} ${headers} ${body}`;
 
             return result;


### PR DESCRIPTION
Closes #286 

I added quotes to the body so it should now work as intended. 

Running the command now returns: 
`{"status":"pending","notificationMethod":"callback","serverCorrelationId":"b0ec3af8-a730-467c-ad5c-4858faca14f5"}`