### PR TITLE
Make Laravel trust all proxies (which is always nginx)

### DIFF
--- a/src/app/Http/Middleware/TrustProxies.php
+++ b/src/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
The problem was that Laravel was outputting HTTP urls when it was served behind a proxy (nginx) which used SSL termination to present an HTTPS interface to our users.

1. The connection starts with an HTTPS connection between browser and our nginx. This is encrypted using the domain certificate, and "Terminated" by nginx (i.e. the proxy connection to the container is made over HTTP). This means that things like the domain certificate don't have to be inside our application container; they can be stored on the host machine which is running nginx.
2. Laravel doesn't know it's behind a TLS proxy, so by default it generates HTTP urls. NGINX has forwarded the `X-Forwarded-Proto` header, but Laravel doesn't know if the header can be trusted or not (anyone could add that header onto the request). I'm not sure exactly what the possible exploit would be here tbh, but I believe there could be one.
3. We know that Laravel is only accessible through our NGINX config, and that NGINX will always set that header (overriding anything set by the original client), which means we actually _do_ trust the header. As a result, we can set `TrustProxies::$proxies = '*'` in the Laravel code, which means we will trust the headers in all incoming requests. If Laravel was accessible through some other external source, we might have to be more precise here. Since the headers are now trusted, Laravel happily accepts that the protocol is https and so it generates URLs with the correct scheme.