### PR TITLE
Single Test Mode

### DIFF
--- a/service.example.env
+++ b/service.example.env
@@ -46,3 +46,16 @@ COMPLIANCE_SESSION_EXECUTION=${COMPLIANCE_SESSION_EXECUTION}
 SESSION_TEST_AVAILABLE=true
 SESSION_TEST_QUESTIONNAIRE_AVAILABLE=true
 SESSION_COMPLIANCE_AVAILABLE=true
+
+# How long should a test run wait for the first message to be sent
+TESTRUN_INITIAL_TIMEOUT=300
+# How long should a test run wait for subsequent messages to be sent
+TESTRUN_STEP_TIMEOUT=30
+# How often to check if a test run is complete
+TESTRUN_TIMEOUT_FREQUENCY=30
+
+# When a test run is in progress, force all incoming messages to match against it (ignoring pattern and triggers)
+FORCE_SEQUENTIAL_TESTS=false
+
+# When there are no active test runs and we receive a message which matches a test case, should we create a new test run?
+CREATE_TESTRUN_ON_MATCH=true

--- a/src/app/Http/Controllers/Sessions/TestRunController.php
+++ b/src/app/Http/Controllers/Sessions/TestRunController.php
@@ -47,8 +47,6 @@ class TestRunController extends Controller
             ->testCases()
             ->where('test_case_id', $testCase->id)
             ->firstOrFail();
-        $testStepFirstSource = $testCase->testSteps()->firstOrFail()->source;
-
         return Inertia::render('sessions/test-runs/show', [
             'session' => (new SessionResource(
                 $session->load([
@@ -95,9 +93,6 @@ class TestRunController extends Controller
             'testCase' => (new TestCaseResource(
                 $testCase->load(['testSteps'])
             ))->resolve(),
-            'testStepFirstSource' => (new ComponentResource(
-                $testStepFirstSource
-            ))->resolve(),
             'testRun' => (new TestRunResource(
                 $testRun->load([
                     'testResults' => function ($query) {
@@ -106,24 +101,26 @@ class TestRunController extends Controller
                 ])
             ))->resolve(),
             'testResult' => (new TestResultResource(
-                $testRun
-                    ->testResults()
-                    ->whereHas('testStep', function (Builder $query) use (
-                        $position
-                    ) {
-                        $query->where('position', $position);
-                    })
-                    ->with([
-                        'testStep' => function ($query) {
-                            return $query->with([
-                                'source',
-                                'target',
-                                'testSetups',
-                            ]);
-                        },
-                        'testExecutions',
-                    ])
-                    ->firstOrFail()
+                optional(
+                    $testRun
+                        ->testResults()
+                        ->whereHas('testStep', function (Builder $query) use (
+                            $position
+                        ) {
+                            $query->where('position', $position);
+                        })
+                        ->with([
+                            'testStep' => function ($query) {
+                                return $query->with([
+                                    'source',
+                                    'target',
+                                    'testSetups',
+                                ]);
+                            },
+                            'testExecutions',
+                        ])
+                        ->first()
+                )
             ))->resolve(),
             'testSteps' => TestStepResource::collection(
                 $testCase

--- a/src/app/Http/Controllers/Sessions/TestStepController.php
+++ b/src/app/Http/Controllers/Sessions/TestStepController.php
@@ -37,7 +37,6 @@ class TestStepController extends Controller
             ->testCases()
             ->where('test_case_id', $testCase->id)
             ->firstOrFail();
-        $testStepFirstSource = $testCase->testSteps()->firstOrFail()->source;
 
         return Inertia::render('sessions/test-steps/index', [
             'session' => (new SessionResource(
@@ -57,9 +56,6 @@ class TestStepController extends Controller
             ))->resolve(),
             'isAvailableRun' => $session->isAvailableTestCaseRun($testCase),
             'testCase' => (new TestCaseResource($testCase))->resolve(),
-            'testStepFirstSource' => (new ComponentResource(
-                $testStepFirstSource
-            ))->resolve(),
             'testSteps' => TestStepResource::collection(
                 $testCase
                     ->testSteps()
@@ -80,7 +76,6 @@ class TestStepController extends Controller
             ->testCases()
             ->where('test_case_id', $testCase->id)
             ->firstOrFail();
-        $testStepFirstSource = $testCase->testSteps()->firstOrFail()->source;
 
         return Inertia::render('sessions/test-steps/flow', [
             'session' => (new SessionResource(
@@ -100,9 +95,6 @@ class TestStepController extends Controller
             ))->resolve(),
             'isAvailableRun' => $session->isAvailableTestCaseRun($testCase),
             'testCase' => (new TestCaseResource($testCase))->resolve(),
-            'testStepFirstSource' => (new ComponentResource(
-                $testStepFirstSource
-            ))->resolve(),
             'testSteps' => TestStepResource::collection(
                 $testCase
                     ->testSteps()

--- a/src/app/Http/Controllers/Testing/SutController.php
+++ b/src/app/Http/Controllers/Testing/SutController.php
@@ -6,6 +6,7 @@ use App\Exceptions\MessageMismatchException;
 use App\Http\Headers\TraceparentHeader;
 use App\Http\Headers\TracestateHeader;
 use App\Models\Component;
+use App\Models\TestRun;
 use App\Models\Group;
 use App\Models\Session;
 use GuzzleHttp\Psr7\Uri;
@@ -100,23 +101,27 @@ class SutController extends Controller
         $component = $this->getComponent($componentId, $session);
         $connection = $this->getComponent($connectionId, $session);
 
-        $testStep = $session
-            ->testSteps()
-            ->where('method', $request->getMethod())
-            ->whereRaw('REGEXP_LIKE(?, pattern)', [$path])
-            ->where(function ($query) use ($request) {
-                $query->whereNull('test_steps.trigger');
-                $query->orWhereRaw('JSON_CONTAINS(?, test_steps.trigger)', [
-                    json_encode($request->getParsedBody()),
-                ]);
-            })
-            ->whereHas('source', function ($query) use ($component) {
-                $query->whereKey($component->getKey());
-            })
-            ->whereHas('target', function ($query) use ($connection) {
-                $query->whereKey($connection->getKey());
-            })
-            ->where(function ($query) {
+        // see if there is a test run currently in progress
+        $currentRun = $session
+            ->testRuns()
+            ->incompleted()
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        if ($currentRun && env('FORCE_SEQUENTIAL_TESTS', false)) {
+            // if there is an ongoing test run, limit the matching to (incomplete) steps inside that run
+            $candidateSteps = $currentRun
+                ->testSteps()
+                ->whereNotExists(function ($query) use ($currentRun) {
+                    $query
+                        ->selectRaw('1')
+                        ->from('test_results')
+                        ->where('test_run_id', '=', $currentRun->id)
+                        ->whereColumn('test_step_id', '=', 'test_steps.id');
+                });
+        } else {
+            // otherwise any step from any test is fair game
+            $candidateSteps = $session->testSteps()->where(function ($query) {
                 $query
                     ->where(function ($query) {
                         $query->where('position', '=', 1);
@@ -148,7 +153,25 @@ class SutController extends Controller
                                 });
                         });
                     });
+            });
+        }
+
+        $testStep = $candidateSteps
+            ->where('method', $request->getMethod())
+            ->whereRaw('REGEXP_LIKE(?, pattern)', [$path])
+            ->where(function ($query) use ($request) {
+                $query->whereNull('test_steps.trigger');
+                $query->orWhereRaw('JSON_CONTAINS(?, test_steps.trigger)', [
+                    json_encode($request->getParsedBody()),
+                ]);
             })
+            ->whereHas('source', function ($query) use ($component) {
+                $query->whereKey($component->getKey());
+            })
+            ->whereHas('target', function ($query) use ($connection) {
+                $query->whereKey($connection->getKey());
+            })
+            ->orderBy('position', 'asc')
             ->first();
 
         if (!$testStep) {
@@ -184,7 +207,21 @@ class SutController extends Controller
             ->testRuns()
             ->incompleted()
             ->where('test_case_id', $testStep->test_case_id)
-            ->firstOrCreate(['test_case_id' => $testStep->test_case_id]);
+            ->firstOr(function () use ($session, $testStep) {
+                if (env('CREATE_TESTRUN_ON_MATCH', false)) {
+                    Log::debug($session->id);
+                    return $session->testRuns()->create([
+                        'test_case_id' => $testStep->test_case_id,
+                    ]);
+                } else {
+                    throw new MessageMismatchException(
+                        $session,
+                        404,
+                        'No test runs are currently in progress for this session. Please initiate a test run by clicking on the "Run Test Case" button, then try again.'
+                    );
+                }
+            });
+
         $testResult = $testRun
             ->testResults()
             ->create(['test_step_id' => $testStep->id]);

--- a/src/app/Observers/TestRunObserver.php
+++ b/src/app/Observers/TestRunObserver.php
@@ -21,7 +21,9 @@ class TestRunObserver
         }
 
         $testRun->increment('total', $testRun->testSteps()->count());
-        CompleteTestRunJob::dispatch($testRun)->delay(now()->addSeconds(30));
+        CompleteTestRunJob::dispatch($testRun)->delay(
+            now()->addSeconds(env('TESTRUN_TIMEOUT_FREQUENCY', 30))
+        );
     }
 
     /**

--- a/src/resources/js/layouts/sessions/test-case.vue
+++ b/src/resources/js/layouts/sessions/test-case.vue
@@ -337,14 +337,7 @@
                                 </inertia-link>
                             </li>
                         </ul>
-                        <div
-                            class="ml-auto"
-                            v-if="
-                                !collect(session.components.data)
-                                    .where('id', testStepFirstSource.id)
-                                    .count()
-                            "
-                        >
+                        <div class="ml-auto">
                             <confirm-link
                                 v-if="isAvailableRun"
                                 :href="
@@ -400,10 +393,6 @@ export default {
             required: true,
         },
         testSteps: {
-            type: Object,
-            required: true,
-        },
-        testStepFirstSource: {
             type: Object,
             required: true,
         },

--- a/src/resources/js/pages/sessions/test-cases/show.vue
+++ b/src/resources/js/pages/sessions/test-cases/show.vue
@@ -3,7 +3,6 @@
         :session="session"
         :test-case="testCase"
         :testSteps="testSteps"
-        :testStepFirstSource="testStepFirstSource"
         :isAvailableRun="isAvailableRun"
         :testRunAttempts="testRunAttempts"
     >
@@ -143,10 +142,6 @@ export default {
             required: true,
         },
         testRuns: {
-            type: Object,
-            required: true,
-        },
-        testStepFirstSource: {
             type: Object,
             required: true,
         },

--- a/src/resources/js/pages/sessions/test-runs/show.vue
+++ b/src/resources/js/pages/sessions/test-runs/show.vue
@@ -4,7 +4,6 @@
         :testCase="testCase"
         :testSteps="testSteps"
         :isAvailableRun="isAvailableRun"
-        :testStepFirstSource="testStepFirstSource"
     >
         <div class="card">
             <div class="card-header">
@@ -97,6 +96,7 @@
                                 -->
                                 <template
                                     v-if="
+                                        testResult.testStep &&
                                         component.id ==
                                             testResult.testStep.data.source
                                                 .id &&
@@ -257,7 +257,10 @@
                             </ul>
                         </div>
                         <div class="col-9 pl-0 pb-4 border-left">
-                            <div class="lead py-3 px-4">
+                            <div
+                                class="lead py-3 px-4"
+                                v-if="testResult.testStep"
+                            >
                                 <div class="d-flex justigy-content-between">
                                     <b class="text-nowrap">
                                         {{
@@ -303,17 +306,33 @@
                                 class="lead mb-2 py-3 px-4"
                                 :class="{
                                     'alert-success': testResult.successful,
-                                    'alert-danger': !testResult.successful,
+                                    'alert-secondary':
+                                        !testResult.testExecutions ||
+                                        !testResult.testExecutions.data.length,
+                                    'alert-danger':
+                                        testResult.testExecutions &&
+                                        testResult.testExecutions.data.length &&
+                                        testResult.successful === false,
                                 }"
                             >
-                                {{ testResult.successful ? 'Pass' : 'Fail' }}
+                                {{
+                                    !testResult.testExecutions ||
+                                    !testResult.testExecutions.data.length
+                                        ? 'Pending'
+                                        : testResult.successful
+                                        ? 'Pass'
+                                        : 'Fail'
+                                }}
                                 <div v-if="testResult.exception">
                                     {{ testResult.exception }}
                                 </div>
                             </div>
                             <div
                                 class="py-2 px-4"
-                                v-if="testResult.testExecutions.data.length"
+                                v-if="
+                                    testResult.testExecutions &&
+                                    testResult.testExecutions.data.length
+                                "
                             >
                                 <div class="d-flex mb-2">
                                     <strong
@@ -837,10 +856,6 @@ export default {
             type: Object,
             required: true,
         },
-        testStepFirstSource: {
-            type: Object,
-            required: true,
-        },
         isAvailableRun: {
             type: Boolean,
             required: true,
@@ -867,6 +882,7 @@ export default {
         },
         testResultRequestSetups() {
             let data = collect();
+            if (!this.testResult.id) return data;
             collect(this.testResult.testStep.data.testSetups)
                 .where('type', 'request')
                 .each((item) => {
@@ -876,6 +892,7 @@ export default {
         },
         testResultResponseSetups() {
             let data = collect();
+            if (!this.testResult.id) return data;
             collect(this.testResult.testStep.data.testSetups)
                 .where('type', 'response')
                 .each((item) => {

--- a/src/resources/js/pages/sessions/test-steps/flow.vue
+++ b/src/resources/js/pages/sessions/test-steps/flow.vue
@@ -4,7 +4,6 @@
         :testCase="testCase"
         :testSteps="testSteps"
         :isAvailableRun="isAvailableRun"
-        :testStepFirstSource="testStepFirstSource"
     >
         <div class="card mb-0">
             <div class="card-header">
@@ -53,10 +52,6 @@ export default {
             required: true,
         },
         testSteps: {
-            type: Object,
-            required: true,
-        },
-        testStepFirstSource: {
             type: Object,
             required: true,
         },

--- a/src/resources/js/pages/sessions/test-steps/index.vue
+++ b/src/resources/js/pages/sessions/test-steps/index.vue
@@ -4,7 +4,6 @@
         :testCase="testCase"
         :testSteps="testSteps"
         :isAvailableRun="isAvailableRun"
-        :testStepFirstSource="testStepFirstSource"
     >
         <div class="card">
             <div class="card-header">
@@ -282,10 +281,6 @@ export default {
             required: true,
         },
         testSteps: {
-            type: Object,
-            required: true,
-        },
-        testStepFirstSource: {
             type: Object,
             required: true,
         },


### PR DESCRIPTION
Resolves #422 (and makes #421 unnecessary for now).

I have added an environment variable called `FORCE_SEQUENTIAL_TESTS`. This variable controls the behaviour when messages are received while a test run is in progress. When `FORCE_SEQUENTIAL_TESTS=true`, all messages which reach the platform while a test run is in progress will exclusively match against that test run. This means that you cannot run parallel tests - if there is a different test case which would match the incoming message, it will not register as a match.

I have also modified the "Run Test Case" button so that it is visible on _all_ test cases, not just those which start with a simulator. If you click it on a test case which begins with a SUT, a test run is initiated without sending the first message. 

These two changes will allow us to be unambiguous in matching test cases. For example, say I have two test cases (A and B) which begin with a `GET /parties/MSISDN/123456789` called by a SUT. Currently we would have problems because both test cases would match an incoming request. However if `FORCE_SEQUENTIAL_TESTS` is enabled, then I can click on "Run Test Case" on test case A. The SUT can then send the request, and ITP will match exclusively against the currently executing test (A). When I want to run test case B, I can click "Run Test Case" on that page, and ITP will match exclusively against that test case.

In order to make this feature easier to use, I have also added environment variables called `TESTRUN_INITIAL_TIMEOUT` and `TESTRUN_STEP_TIMEOUT`. This allows us to say (for example) that the first step in a test case must be received within 300s of the "Run Test Case" button being clicked, while retaining a 30s timeout for subsequent steps.

Finally, I have added a variable called `CREATE_TESTRUN_ON_MATCH`. This controls whether a test run is automatically started when there are no current test runs and a request matching some test case reaches the platform. Setting the variable to `false` will mean that the _only_ way to start a test run will be to click on "Run Test Case". The default value is `true`, which will continue the current behaviour of initiating a test case automatically when a matching request is receieved.

There are also some minor changes to the UI to make this experience work better.