### PR TITLE
Hide session URL when a group URL is available

### DIFF
--- a/src/app/Http/Exports/ComplianceSessionExport.php
+++ b/src/app/Http/Exports/ComplianceSessionExport.php
@@ -99,7 +99,7 @@ class ComplianceSessionExport
         $table->addCell(1500)->addText(__('Attempts'), $style);
 
         foreach ($session->testCases as $testCase) {
-            $status = __('Incompleted');
+            $status = __('Incomplete');
 
             /** @var TestRun $lastTestRun */
             $lastTestRun = $testCase

--- a/src/resources/js/layouts/sessions/test-case.vue
+++ b/src/resources/js/layouts/sessions/test-case.vue
@@ -1,5 +1,5 @@
 <template>
-    <layout
+    <app-layout
         :session="session"
         :breadcrumbs="[
             { name: 'Sessions', url: route('sessions.index') },
@@ -56,137 +56,104 @@
                                     Download certificates
                                 </a>
                             </div>
-                            <template
-                                v-if="
-                                    $page.props.auth.user.groups &&
-                                    $page.props.auth.user.groups.length > 0 &&
-                                    $page.props.auth.user.groups.some(
-                                        (el) =>
-                                            el.default_session_id === session.id
-                                    )
-                                "
-                            >
-                                <div>
-                                    <button
-                                        type="button"
-                                        class="btn btn-link dropdown-toggle px-0 mb-0"
-                                        v-b-toggle="`by-groups`"
-                                    >
-                                        By groups
-                                    </button>
-                                </div>
-                                <b-collapse id="by-groups">
-                                    <template
-                                        v-for="(group, i) in $page.props.auth
-                                            .user.groups"
-                                    >
-                                        <div
-                                            v-if="
-                                                group.default_session_id ===
-                                                session.id
-                                            "
-                                            :key="`group-${i}`"
-                                        >
-                                            <h4 class="text-secondary">
-                                                {{ group.name }}
-                                            </h4>
-                                            <template
-                                                v-for="(component, j) in session
-                                                    .components.data"
-                                            >
-                                                <div
-                                                    v-if="
-                                                        Array.from(
-                                                            new Set(
-                                                                testSteps.data.map(
-                                                                    (el) =>
-                                                                        el
-                                                                            .source
-                                                                            .id
-                                                                )
-                                                            )
-                                                        ).includes(component.id)
-                                                    "
-                                                    class="mb-3"
-                                                    :key="`component-${j}`"
-                                                >
-                                                    <h4>
-                                                        {{ component.name }}
-                                                    </h4>
-                                                    <div
-                                                        class="mb-3"
-                                                        v-for="(
-                                                            connection, k
-                                                        ) in component.connections"
-                                                        :key="`connection-${k}`"
-                                                    >
-                                                        <template
-                                                            v-if="
-                                                                Array.from(
-                                                                    new Set(
-                                                                        testSteps.data.map(
-                                                                            (
-                                                                                el
-                                                                            ) =>
-                                                                                el
-                                                                                    .target
-                                                                                    .id
-                                                                        )
-                                                                    )
-                                                                ).includes(
-                                                                    connection.id
-                                                                )
-                                                            "
-                                                            class="mb-3"
-                                                        >
-                                                            <label>
-                                                                {{
-                                                                    connection.name
-                                                                }}
-                                                            </label>
-                                                            <div
-                                                                class="input-group"
-                                                            >
-                                                                <input
-                                                                    :id="`testing-${group.id}-${component.id}-${connection.id}`"
-                                                                    type="text"
-                                                                    :value="
-                                                                        getRoute(
-                                                                            component.use_encryption,
-                                                                            [
-                                                                                group.id,
-                                                                                component.uuid,
-                                                                                connection.uuid,
-                                                                            ],
-                                                                            true
-                                                                        )
-                                                                    "
-                                                                    class="form-control"
-                                                                    readonly
-                                                                />
-                                                                <clipboard-copy-btn
-                                                                    :target="`#testing-${group.id}-${component.id}-${connection.id}`"
-                                                                    title="Copy"
-                                                                ></clipboard-copy-btn>
-                                                            </div>
-                                                        </template>
-                                                    </div>
-                                                </div>
-                                            </template>
-                                        </div>
-                                    </template>
-                                </b-collapse>
-                            </template>
-                            <div>
-                                <button
-                                    type="button"
-                                    class="btn btn-link dropdown-toggle px-0 mb-0"
-                                    v-b-toggle="`by-session`"
+                            <div id="by-groups" v-if="hasGroupUrls">
+                                <template
+                                    v-for="(group, i) in $page.props.auth.user
+                                        .groups"
                                 >
-                                    By session
-                                </button>
+                                    <div
+                                        v-if="
+                                            group.default_session_id ===
+                                            session.id
+                                        "
+                                        :key="`group-${i}`"
+                                    >
+                                        <h4 class="text-secondary">
+                                            {{ group.name }} URLs:
+                                        </h4>
+                                        <template
+                                            v-for="(component, j) in session
+                                                .components.data"
+                                        >
+                                            <div
+                                                v-if="
+                                                    Array.from(
+                                                        new Set(
+                                                            testSteps.data.map(
+                                                                (el) =>
+                                                                    el.source.id
+                                                            )
+                                                        )
+                                                    ).includes(component.id)
+                                                "
+                                                class="mb-3"
+                                                :key="`component-${j}`"
+                                            >
+                                                <h4>
+                                                    {{ component.name }}
+                                                </h4>
+                                                <div
+                                                    class="mb-3"
+                                                    v-for="(
+                                                        connection, k
+                                                    ) in component.connections"
+                                                    :key="`connection-${k}`"
+                                                >
+                                                    <template
+                                                        v-if="
+                                                            Array.from(
+                                                                new Set(
+                                                                    testSteps.data.map(
+                                                                        (el) =>
+                                                                            el
+                                                                                .target
+                                                                                .id
+                                                                    )
+                                                                )
+                                                            ).includes(
+                                                                connection.id
+                                                            )
+                                                        "
+                                                        class="mb-3"
+                                                    >
+                                                        <label>
+                                                            {{
+                                                                connection.name
+                                                            }}
+                                                        </label>
+                                                        <div
+                                                            class="input-group"
+                                                        >
+                                                            <input
+                                                                :id="`testing-${group.id}-${component.id}-${connection.id}`"
+                                                                type="text"
+                                                                :value="
+                                                                    getRoute(
+                                                                        component.use_encryption,
+                                                                        [
+                                                                            group.id,
+                                                                            component.uuid,
+                                                                            connection.uuid,
+                                                                        ],
+                                                                        true
+                                                                    )
+                                                                "
+                                                                class="form-control"
+                                                                readonly
+                                                            />
+                                                            <clipboard-copy-btn
+                                                                :target="`#testing-${group.id}-${component.id}-${connection.id}`"
+                                                                title="Copy"
+                                                            ></clipboard-copy-btn>
+                                                        </div>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
                             </div>
-                            <b-collapse id="by-session">
+                            <template id="by-session" v-if="!hasGroupUrls">
                                 <template
                                     v-for="(component, i) in session.components
                                         .data"
@@ -255,7 +222,7 @@
                                         </template>
                                     </div>
                                 </template>
-                            </b-collapse>
+                            </template>
                         </li>
                         <li v-if="testCase.description" class="mb-3">
                             <h3>
@@ -380,15 +347,15 @@
                 </div>
             </div>
         </div>
-    </layout>
+    </app-layout>
 </template>
 
 <script>
-import Layout from '@/layouts/sessions/app';
+import AppLayout from '@/layouts/sessions/app';
 
 export default {
     components: {
-        Layout,
+        AppLayout,
     },
     props: {
         session: {
@@ -426,6 +393,12 @@ export default {
                 this.session.components.data?.filter(
                     (component) => component.use_encryption
                 )?.length > 0,
+            hasGroupUrls:
+                this.$page.props.auth.user.groups &&
+                this.$page.props.auth.user.groups.length > 0 &&
+                this.$page.props.auth.user.groups.some(
+                    (el) => el.default_session_id === this.session.id
+                ),
         };
     },
     methods: {

--- a/src/resources/js/pages/sessions/edit.vue
+++ b/src/resources/js/pages/sessions/edit.vue
@@ -351,7 +351,7 @@
                                 "
                             >
                                 <label>
-                                    <b>Session default for groups</b>
+                                    <b>Default session for groups</b>
                                 </label>
                                 <v-select
                                     :value="$page.props.auth.user.groups"

--- a/src/resources/js/pages/sessions/register/config.vue
+++ b/src/resources/js/pages/sessions/register/config.vue
@@ -1,14 +1,20 @@
 <template>
     <layout :components="components" :session="session">
         <form @submit.prevent="submit" class="col-8 m-auto">
-            <div class="card mb-3" v-if="groupsDefaultList.length > 0">
+            <div class="card">
                 <div class="card-header">
-                    <h3 class="card-title">
-                        Make this session default for groups
-                    </h3>
+                    <h3 class="card-title">Configure components</h3>
                 </div>
-                <div class="card-body">
-                    <label class="form-label">Set groups</label>
+
+                <div class="card-body" v-if="groupsDefaultList.length">
+                    <label class="form-label">Group Default Sessions</label>
+                    <p>
+                        You can choose to make this session the default session
+                        for your group to allow your components to continue
+                        using a static URL. By making this the default session,
+                        your components will stop sending traffic to any
+                        previously selected sessions.
+                    </p>
                     <v-select
                         v-model="form.groupsDefault"
                         :options="groupsDefaultList"
@@ -28,102 +34,74 @@
                         class="form-control d-flex p-0 mb-3"
                     />
                 </div>
-            </div>
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="card-title">Configure components</h3>
-                </div>
-                <template
-                    v-if="form.groupsDefault && form.groupsDefault.length > 0"
-                >
-                    <div
-                        class="card-body"
-                        v-if="suts.data && suts.data.length > 0"
-                    >
-                        <button
-                            type="button"
-                            class="btn btn-link card-title dropdown-toggle px-0 mb-0"
-                            v-b-toggle="'config-by-groups'"
-                        >
-                            By groups
-                        </button>
-                        <b-collapse id="config-by-groups" visible>
-                            <template v-for="(group, k) in form.groupsDefault">
-                                <h3
-                                    class="text-secondary mb-3"
-                                    :key="`name-${k}`"
-                                >
-                                    {{ group.name }}
-                                </h3>
-                                <div
-                                    class="mb-3"
-                                    v-for="(sut, i) in suts.data"
-                                    :key="`sut-${i}-${k}`"
-                                >
-                                    <h3>{{ sut.name }}</h3>
 
-                                    <template
-                                        v-for="(
-                                            connection, j
-                                        ) in sut.connections"
-                                    >
-                                        <div
-                                            class="mb-3"
-                                            :key="`connection-${j}`"
-                                            v-if="
-                                                Array.from(
-                                                    new Set(
-                                                        testSteps.data.map(
-                                                            (el) => el.target.id
-                                                        )
-                                                    )
-                                                ).includes(connection.id)
-                                            "
-                                        >
-                                            <label class="form-label">
-                                                {{ connection.name }}
-                                            </label>
-                                            <div class="input-group">
-                                                <input
-                                                    :id="`testing-${connection.id}`"
-                                                    type="text"
-                                                    :value="
-                                                        getRoute(
-                                                            session.sut[sut.id]
-                                                                .use_encryption ===
-                                                                '1',
-                                                            [
-                                                                group.id,
-                                                                sut.uuid,
-                                                                connection.uuid,
-                                                            ],
-                                                            true
-                                                        )
-                                                    "
-                                                    class="form-control"
-                                                    readonly
-                                                />
-                                                <clipboard-copy-btn
-                                                    :target="`#testing-${connection.id}`"
-                                                    title="Copy"
-                                                ></clipboard-copy-btn>
-                                            </div>
-                                        </div>
-                                    </template>
-                                </div>
-                            </template>
-                        </b-collapse>
-                    </div>
-                </template>
-                <div class="card-body" v-if="suts.data && suts.data.length > 0">
-                    <button
-                        type="button"
-                        class="btn btn-link card-title dropdown-toggle px-0 mb-0"
-                        v-b-toggle="'config-by-session'"
+                <div class="card-body" v-if="suts.data && suts.data.length">
+                    <template
+                        v-if="form.groupsDefault && form.groupsDefault.length"
                     >
-                        By session
-                    </button>
-                    <b-collapse id="config-by-session" visible>
+                        <template v-for="(group, k) in form.groupsDefault">
+                            <h3 class="text-secondary mb-3" :key="`name-${k}`">
+                                {{ group.name }} URLs:
+                            </h3>
+                            <div
+                                class="mb-3"
+                                v-for="(sut, i) in suts.data"
+                                :key="`sut-${i}-${k}`"
+                            >
+                                <h3>{{ sut.name }}</h3>
+
+                                <template
+                                    v-for="(connection, j) in sut.connections"
+                                >
+                                    <div
+                                        class="mb-3"
+                                        :key="`connection-${j}`"
+                                        v-if="
+                                            Array.from(
+                                                new Set(
+                                                    testSteps.data.map(
+                                                        (el) => el.target.id
+                                                    )
+                                                )
+                                            ).includes(connection.id)
+                                        "
+                                    >
+                                        <label class="form-label">
+                                            {{ connection.name }}
+                                        </label>
+                                        <div class="input-group">
+                                            <input
+                                                :id="`testing-${connection.id}`"
+                                                type="text"
+                                                :value="
+                                                    getRoute(
+                                                        session.sut[sut.id]
+                                                            .use_encryption ===
+                                                            '1',
+                                                        [
+                                                            group.id,
+                                                            sut.uuid,
+                                                            connection.uuid,
+                                                        ],
+                                                        true
+                                                    )
+                                                "
+                                                class="form-control"
+                                                readonly
+                                            />
+                                            <clipboard-copy-btn
+                                                :target="`#testing-${connection.id}`"
+                                                title="Copy"
+                                            ></clipboard-copy-btn>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+                    </template>
+                    <template
+                        v-if="!form.groupsDefault || !form.groupsDefault.length"
+                    >
                         <template v-for="(sut, i) in suts.data">
                             <h3 :key="`sut-${i}`">{{ sut.name }}</h3>
                             <template
@@ -171,7 +149,7 @@
                                 </div>
                             </template>
                         </template>
-                    </b-collapse>
+                    </template>
                 </div>
                 <div class="card-body">
                     <div class="mb-3">


### PR DESCRIPTION
A user never* needs to see both the session URLs _and_ the group URLs. In this PR I clean up the interface slightly so that group URLs are always shown when they are available, and session URLs only shown when there are no group URLs to use. 

*I think this is true, but we can revert if someone can come up with a good use case for seeing both session and group URLs at once! 